### PR TITLE
Fix for strtobool

### DIFF
--- a/network_apis/utils/logging.py
+++ b/network_apis/utils/logging.py
@@ -6,5 +6,5 @@ import logging
 from distutils.util import strtobool
 
 formatting = '[%(asctime)s][%(name)s][%(process)d %(processName)s][%(levelname)-8s] (L:%(lineno)s) %(module)s | %(funcName)s: %(message)s'
-logging.basicConfig(level=logging.DEBUG if bool(strtobool(os.environ.get('DEBUG', False))) else logging.INFO, format=formatting)
+logging.basicConfig(level=logging.DEBUG if bool(strtobool(os.environ.get('DEBUG', 'False'))) else logging.INFO, format=formatting)
 LOG = logging.getLogger("bn")

--- a/network_apis/utils/utils.py
+++ b/network_apis/utils/utils.py
@@ -144,9 +144,9 @@ async def query_service(service, params, access_token, ws=None):
     async with aiohttp.ClientSession() as session:
         try:
             async with session.get(service,
-                                   params=params,
-                                   ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', False))),
-                                   headers=headers) as response:
+                                    params=params,
+                                    ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False'))),
+                                    headers=headers) as response:
                 # On successful response, forward response
                 if response.status == 200:
                     result = await response.json()
@@ -159,8 +159,8 @@ async def query_service(service, params, access_token, ws=None):
                 else:
                     # HTTP errors
                     error = {"service": service,
-                             "queryParams": params,
-                             "responseStatus": response.status}
+                                "queryParams": params,
+                                "responseStatus": response.status}
                     if ws:
                         return await ws.send_str(json.dumps(str(error)))
                     else:

--- a/ui/beacon_auth/wsgi.py
+++ b/ui/beacon_auth/wsgi.py
@@ -92,14 +92,14 @@ def elixir_callback():
         response.set_cookie('access_token',
                             access_token,
                             max_age=int(os.environ.get('COOKIE_AGE', 3600)),
-                            secure=bool(strtobool(os.environ.get('COOKIE_SECURE', True))),
+                            secure=bool(strtobool(os.environ.get('COOKIE_SECURE', 'True'))),
                             domain=os.environ.get('COOKIE_DOMAIN', None))
         if get_bona_fide_status(access_token):
             # If user has bona fide status, add a cookie for this
             response.set_cookie('bona_fide_status',
                                 BONA_FIDE_URL,
                                 max_age=int(os.environ.get('COOKIE_AGE', 3600)),
-                                secure=bool(strtobool(os.environ.get('COOKIE_SECURE', True))),
+                                secure=bool(strtobool(os.environ.get('COOKIE_SECURE', 'True'))),
                                 domain=os.environ.get('COOKIE_DOMAIN', None))
     except Exception as e:
         LOG.error(str(e))
@@ -139,10 +139,10 @@ def get_bona_fide_status(access_token):
 def main():
     """Start the web server."""
     application.secret_key = os.environ.get('COOKIE_SECRET', None)
-    application.config['SESSION_COOKIE_SECURE'] = bool(strtobool(os.environ.get('SESSION_COOKIE_SECURE', True)))
+    application.config['SESSION_COOKIE_SECURE'] = bool(strtobool(os.environ.get('SESSION_COOKIE_SECURE', 'True')))
     application.run(host=os.environ.get('APP_HOST', 'localhost'),
                     port=int(os.environ.get('APP_PORT', 8080)),
-                    debug=bool(strtobool(os.environ.get('APP_DEBUG', True))))
+                    debug=bool(strtobool(os.environ.get('APP_DEBUG', 'True'))))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When we moved from custom boolean handler to python's own `strtobool` function, it broke some parameters, because `strtobool` requires parameter to **always** be `str`, when it in fact defaulted to `bool` in parameters.

[Custom Solution](https://github.com/CSCfi/beacon-network/blob/55cca9d54a12d394a0db565acc0878f37eb31773/network_apis/utils/utils.py#L179-L198) vs [Python's distutils](https://github.com/python/cpython/blob/master/Lib/distutils/util.py#L294-L307)