### PR TITLE
Remote registering

### DIFF
--- a/network_apis/aggregator.py
+++ b/network_apis/aggregator.py
@@ -109,12 +109,10 @@ async def services_post(request):
     db_pool = request.app['pool']
 
     # Send request for processing
-    service_key = await register_service(request, db_pool)
+    response = await register_service(request, db_pool)
 
     # Return confirmation and service key if no problems occurred during processing
-    response = {'message': 'Service has been registered. Service key for updating and deleting registration included in this response, keep it safe.',
-                'beaconServiceKey': service_key}
-    return web.HTTPCreated(body=json.dumps(response))
+    return web.HTTPCreated(body=json.dumps(response), content_type='application/json')
 
 
 @routes.get('/services')

--- a/network_apis/db/docker-entrypoint-initdb.d/init.sql
+++ b/network_apis/db/docker-entrypoint-initdb.d/init.sql
@@ -42,6 +42,11 @@ CREATE TABLE api_keys (
     comment VARCHAR(256)
 );
 
+CREATE TABLE remote_keys (
+    remote_service VARCHAR(64),
+    service_key VARCHAR(64)
+);
+
 /* NOT IMPLEMENTED */
 
 -- CREATE TABLE IF NOT EXISTS networks (

--- a/network_apis/endpoints/services.py
+++ b/network_apis/endpoints/services.py
@@ -20,7 +20,7 @@ async def register_service(request, db_pool):
         # This option is used at Aggregators when they do a remote registration at a Registry
         LOG.debug(f'Remote registration request to {params["remote"]}.')
         # Register self (aggregator) at remote service (registry) via self, not manually
-        service_key = await remote_registration(db_pool, request)
+        service_key = await remote_registration(db_pool, request, params['remote'])
         return service_key
     else:
         LOG.debug('Local registration at host.')

--- a/network_apis/registry.py
+++ b/network_apis/registry.py
@@ -61,15 +61,13 @@ async def services_post(request):
     db_pool = request.app['pool']
 
     # Send request for processing
-    service_key = await register_service(request, db_pool)
+    response = await register_service(request, db_pool)
 
     # Notify aggregators of changed service catalogue
     await remote_recache_aggregators(request, db_pool)
 
     # Return confirmation and service key if no problems occurred during processing
-    response = {'message': 'Service has been registered. Service key for updating and deleting registration included in this response, keep it safe.',
-                'beaconServiceKey': service_key}
-    return web.HTTPCreated(body=json.dumps(response))
+    return web.HTTPCreated(body=json.dumps(response), content_type='application/json')
 
 
 @routes.get('/services')

--- a/network_apis/utils/db_ops.py
+++ b/network_apis/utils/db_ops.py
@@ -265,7 +265,7 @@ async def db_verify_service_key(connection, service_id=None, service_key=None, a
             response = await statement.fetch(service_id, service_key)
         else:
             # Use case for accessing remote Aggregator's PUT /beacons endpoint
-            query = """SELECT service_id FROM service_keys WHERE service_key=$1"""
+            query = """SELECT remote_service FROM remote_keys WHERE service_key=$1"""
             statement = await connection.prepare(query)
             response = await statement.fetch(service_key)
     except Exception as e:

--- a/network_apis/utils/utils.py
+++ b/network_apis/utils/utils.py
@@ -263,9 +263,9 @@ async def notify_service(service, beacons):
         # Solution for prototype, figure out a better way later
         # serviceUrl from DB: `https://../` append with `beacons`
         async with session.put(f'{service["service_url"]}beacons',
-                                headers={'Beacon-Service-Key': service['service_key']},
-                                data=beacons,
-                                ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False')))) as response:
+                               headers={'Beacon-Service-Key': service['service_key']},
+                               data=beacons,
+                               ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False')))) as response:
             if response.status in [200, 201, 204]:
                 # 201 - cache didn't exist, and was created
                 # 200/204 - cache existed, and was overwritten
@@ -347,8 +347,8 @@ async def http_verify_remote(remote):
         try:
             # serviceUrl should be of form: `https://../` append with `info`
             async with session.get(f'{remote}info',
-                                    params=params,
-                                    ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False')))) as response:
+                                   params=params,
+                                   ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False')))) as response:
                 if response.status == 200:
                     result = await response.json()
                     if result['serviceType'] == 'GA4GHRegistry':
@@ -408,8 +408,8 @@ async def db_store_my_service_key(db_pool, remote_service, service_key):
             # Database commit occurs on transaction closure
             async with connection.transaction():
                 await connection.execute("""INSERT INTO remote_keys (remote_service, service_key)
-                                        VALUES ($1, $2)""",
-                                        remote_service, service_key)
+                                         VALUES ($1, $2)""",
+                                         remote_service, service_key)
         except Exception as e:
             LOG.debug(f'DB error: {e}')
             raise web.HTTPInternalServerError(text='Database error occurred while attempting to store remote service key.')

--- a/network_apis/utils/validate.py
+++ b/network_apis/utils/validate.py
@@ -77,7 +77,7 @@ def api_key():
             LOG.debug('In /services endpoint.')
             if request.method == 'POST':
                 LOG.debug('Using POST method.')
-                if 'remote' in request.rel_url.query.items():
+                if 'remote' in request.rel_url.query:
                     LOG.debug('Registering at remote, check that api key exists, but don\'t verify it.')
                     try:
                         post_api_key = request.headers['Remote-Api-Key']


### PR DESCRIPTION
Implements remote registering of Aggregators at Registries to authenticate re-caching events originating from Registries.

What's new?
`?remote=` path param can be used at `Aggregator POST /services`. The remote-keyword takes a URL to a Registry as value. This parameter makes the Aggregator to forward the registration to the target remote Registry instead of its local database.

How does it work?
* Aggregator registers itself remotely to a Registry;
* Registry generates a service key for Aggregator as per usual, and returns it in response;
* Aggregator stores the service key from response;
* When the Beacon list is updated at Registry, and the Registry sends new Beacon URLs to Aggregators;
* The Registry uses the Aggregator's service key to authenticate itself to pass through the PUT endpoint.

This remote registration is completely voluntary. Recaching still works when initiated from the Aggregator's side. The Aggregator's cache is kept for 24 hours, after which a new cache is requested upon the next Beacon query. This feature only lets Registries use the Aggregator's PUT endpoint securely to update the cache at a faster pace.