### PR TITLE
Change how query endpoint is handled

### DIFF
--- a/network_apis/utils/utils.py
+++ b/network_apis/utils/utils.py
@@ -289,8 +289,8 @@ async def query_service(service, params, access_token, ws=None):
     # Query service in a session
     async with aiohttp.ClientSession() as session:
         try:
-            # serviceUrl from DB: `https://../query`, beacon serviceUrls should end with /query
-            async with session.get(service,
+            # serviceUrl from DB: `https://../` append with `query`
+            async with session.get(f'{service}query',
                                    params=params,
                                    ssl=bool(strtobool(os.environ.get('HTTPS_ONLY', 'False'))),
                                    headers=headers) as response:

--- a/ui/ui/newbeacon/newbeacon.js
+++ b/ui/ui/newbeacon/newbeacon.js
@@ -36,7 +36,7 @@ angular.module('beaconApp.newbeacon', ['ngRoute'])
             $scope.beaconInfo.serviceType = 'GA4GHBeacon';
           }
           if (!$scope.beaconInfo.hasOwnProperty('serviceUrl')) {
-            $scope.beaconInfo.serviceUrl = `${$scope.beaconURL}query`;
+            $scope.beaconInfo.serviceUrl = $scope.beaconURL;
           }
           if (!$scope.beaconInfo.hasOwnProperty('open')) {
             $scope.beaconInfo.open = true;


### PR DESCRIPTION
`serviceUrl` should be root endpoint `https://address/` not `https://address/query`