### PR TITLE
Spec to docs

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,6 +1,6 @@
 API Examples
 ============
 
-Practical examples on how to use the APIs.
+For reference on how to use the API endpoints, please refer to the specification below:
 
-`TO DO`.
+`API Specification for the current version in master <https://editor.swagger.io/?url=https://gist.githubusercontent.com/teemukataja/b583bd9c6c57afa9a04024f070c79a5b/raw/a7bad001da7aae4c61809c3da259b17594313581/beacon-network-specification-0_1.yml>`_.


### PR DESCRIPTION
Add link to specification document that describes the current state of the API in master.