### PR TITLE
New mechanism for updating Aggregator's cache

### DIFF
--- a/network_apis/aggregator.py
+++ b/network_apis/aggregator.py
@@ -58,7 +58,7 @@ async def query(request):
 
 
 @routes.delete('/beacons')
-async def recache(request):
+async def beacons(request):
     """Invalidate cached Beacons."""
     LOG.debug('DELETE /beacons received.')
 

--- a/network_apis/aggregator.py
+++ b/network_apis/aggregator.py
@@ -12,7 +12,7 @@ from endpoints.info import get_info
 from endpoints.service_types import get_service_types
 from endpoints.services import register_service, get_services, update_service, delete_services
 from endpoints.query import send_beacon_query, send_beacon_query_websocket
-from endpoints.beacons import recache_beacons
+from endpoints.beacons import invalidate_cache
 from schemas import load_schema
 from utils.utils import application_security
 from utils.validate import validate, api_key
@@ -57,24 +57,16 @@ async def query(request):
         return web.json_response(response)
 
 
-@routes.put('/beacons')
-@validate(load_schema("beacons"))
+@routes.delete('/beacons')
 async def recache(request):
-    """Update cached Beacons."""
-    LOG.debug('PUT /beacons received.')
-    # Tap into the database pool
-    db_pool = request.app['pool']
+    """Invalidate cached Beacons."""
+    LOG.debug('DELETE /beacons received.')
 
     # Send request for processing
-    response = await recache_beacons(request, db_pool)
+    await invalidate_cache()
 
-    if response == 201:
-        return web.HTTPCreated(text='New cache was created.')
-    elif response == 204:
-        # Overwriting existing cache gives 204
-        return web.HTTPNoContent()
-    else:
-        return web.HTTPInternalServerError(text='Could not set cache.')
+    # Return confirmation
+    return web.HTTPNoContent()
 
 
 @routes.get('/info')

--- a/network_apis/endpoints/beacons.py
+++ b/network_apis/endpoints/beacons.py
@@ -6,21 +6,14 @@ import uvloop
 
 
 from utils.logging import LOG
-from utils.utils import clear_cache, cache_from_registry
+from utils.utils import clear_cache
 
 asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
-async def recache_beacons(request, db_pool):
-    """Delete local Beacon cache and request new information from Registry."""
-    LOG.debug('Starting re-caching of Beacons.')
-    # Get POST request body JSON as python dict
-    beacons = await request.json()
+async def invalidate_cache():
+    """Delete local Beacon cache."""
+    LOG.debug('Invalidate cached Beacons.')
 
-    response = await clear_cache()
-    LOG.debug('Cache has been cleared.')
-
-    response = await cache_from_registry(beacons, response)  # re-caching happens here
-    LOG.debug('Cache has been renewed.')
-
-    return response
+    await clear_cache()
+    LOG.debug('Cache invalidating procedure complete.')

--- a/network_apis/registry.py
+++ b/network_apis/registry.py
@@ -12,7 +12,7 @@ from endpoints.info import get_info
 from endpoints.service_types import get_service_types
 from endpoints.services import register_service, get_services, update_service, delete_services
 from schemas import load_schema
-from utils.utils import remote_recache_aggregators, application_security
+from utils.utils import invalidate_aggregator_caches, application_security
 from utils.validate import validate, api_key
 from utils.db_pool import init_db_pool
 from utils.logging import LOG
@@ -64,7 +64,7 @@ async def services_post(request):
     response = await register_service(request, db_pool)
 
     # Notify aggregators of changed service catalogue
-    await remote_recache_aggregators(request, db_pool)
+    await invalidate_aggregator_caches(request, db_pool)
 
     # Return confirmation and service key if no problems occurred during processing
     return web.HTTPCreated(body=json.dumps(response), content_type='application/json')
@@ -101,7 +101,7 @@ async def services_put(request):
     await update_service(request, db_pool)
 
     # Notify aggregators of changed service catalogue
-    await remote_recache_aggregators(request, db_pool)
+    await invalidate_aggregator_caches(request, db_pool)
 
     # Return confirmation
     return web.HTTPNoContent()
@@ -121,7 +121,7 @@ async def services_delete(request):
     await delete_services(request, db_pool)
 
     # Notify aggregators of changed service catalogue
-    await remote_recache_aggregators(request, db_pool)
+    await invalidate_aggregator_caches(request, db_pool)
 
     # Return confirmation
     return web.HTTPNoContent()


### PR DESCRIPTION
Instead of `PUT /beacons` at Aggregator with list of Beacons, invalidate current cache at Aggregator with `DELETE /beacons` and let Aggregator fetch a new list of Beacons when a query is made (which doesn't happen frequently).