### PR TITLE
Use jsonschema v3.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ aiomcache
 ujson
 uvloop
 asyncpg
-jsonschema==3.0.1
+jsonschema==3.0.2
 gunicorn


### PR DESCRIPTION
Use the same jsonschema version as the beacon-python, so that they can be run in the same container.