### PR TITLE
Return more error info

### DIFF
--- a/aggregator/utils/utils.py
+++ b/aggregator/utils/utils.py
@@ -254,10 +254,10 @@ async def query_service(service, params, access_token, ws=None):
                         return result
                 else:
                     # HTTP errors
-                    error = {"service": service[0], "queryParams": params, "responseStatus": response.status}
+                    error = {"service": service[0], "queryParams": params, "responseStatus": response.status, "exists": None}
                     LOG.error(f"Query to {service} failed: {response}.")
-                    if ws:
-                        return await ws.send_str(json.dumps(str(error)))
+                    if isinstance(ws, web.WebSocketResponse):
+                        return await ws.send_str(json.dumps(error))
                     else:
                         return error
 

--- a/aggregator/utils/utils.py
+++ b/aggregator/utils/utils.py
@@ -235,7 +235,7 @@ async def query_service(service, params, access_token, ws=None):
                 # On successful response, forward response
                 if response.status == 200:
                     result = await response.json()
-                    if isinstance(ws, web.WebSocketResponse):
+                    if ws is not None:
                         # If the response comes from another aggregator, it's a list, and it needs to be broken down into dicts
                         if isinstance(result, list):
                             tasks = []
@@ -256,7 +256,7 @@ async def query_service(service, params, access_token, ws=None):
                     # HTTP errors
                     error = {"service": service[0], "queryParams": params, "responseStatus": response.status, "exists": None}
                     LOG.error(f"Query to {service} failed: {response}.")
-                    if isinstance(ws, web.WebSocketResponse):
+                    if ws is not None:
                         return await ws.send_str(json.dumps(error))
                     else:
                         return error


### PR DESCRIPTION
### Description

Back end for beacon ui issue 39. Returns more data of errored beacon connections.

### Related issues

beacon ui issue 39

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes Made

agregator/util/utils.py query_service now returns error info and tests were updated to match

### Testing

- [x] Unit Tests

### Mentions
Thanks to Teemu for making everything work.
